### PR TITLE
(#435) Added the ability to set optional arguments for the queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii2 Queue Extension Change Log
 -----------------------
 
 - Enh #430: Added configurable AMQP Exchange type (s1lver)
+- Enh #435: Added the ability to set optional arguments for the AMQP queue (s1lver)
 
 
 2.3.2 May 05, 2021

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -169,7 +169,14 @@ class Queue extends CliQueue
      */
     public $queueName = 'interop_queue';
     /**
-     * Setting optional arguments for the queue
+     * Setting optional arguments for the queue (key-value pairs)
+     * ```php
+     * [
+     *    'x-expires' => 300000,
+     *    'x-max-priority' => 10
+     * ]
+     * ```
+     *
      * @var array
      * @since 2.3.3
      * @see https://www.rabbitmq.com/queues.html#optional-arguments

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -169,6 +169,13 @@ class Queue extends CliQueue
      */
     public $queueName = 'interop_queue';
     /**
+     * Setting optional arguments for the queue
+     * @var array
+     * @since 2.3.3
+     * @see https://www.rabbitmq.com/queues.html#optional-arguments
+     */
+    public $queueOptionalArguments = [];
+    /**
      * The exchange used to publish messages to.
      *
      * @var string
@@ -412,7 +419,10 @@ class Queue extends CliQueue
 
         $queue = $this->context->createQueue($this->queueName);
         $queue->addFlag(AmqpQueue::FLAG_DURABLE);
-        $queue->setArguments(['x-max-priority' => $this->maxPriority]);
+        $queue->setArguments(array_merge(
+            ['x-max-priority' => $this->maxPriority],
+            $this->queueOptionalArguments
+        ));
         $this->context->declareQueue($queue);
 
         $topic = $this->context->createTopic($this->exchangeName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #435 


It may then be necessary to remove the option `maxPriority`?

```php
public $maxPriority = 10;
```

But this will break backward compatibility. 