### PR TITLE
Prevent multiple execution of aborted jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii2 Queue Extension Change Log
 -----------------------
 - Enh #516: Ensure Redis driver messages are consumed at least once (soul11201)
 - Bug #522: Fix SQS driver type error with custom value passed to `queue/listen` (flaviovs)
-- Bug #528: Prevent multiple execution of aborted jobs
+- Bug #528: Prevent multiple execution of aborted jobs (luke-)
 
 2.3.7 April 29, 2024
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii2 Queue Extension Change Log
 -----------------------
 - Enh #516: Ensure Redis driver messages are consumed at least once (soul11201)
 - Bug #522: Fix SQS driver type error with custom value passed to `queue/listen` (flaviovs)
-
+- Bug #528: Prevent multiple execution of aborted jobs
 
 2.3.7 April 29, 2024
 --------------------

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -230,7 +230,7 @@ abstract class Queue extends Component
         if ($attempt > 1) {
             if ($job instanceof RetryableJobInterface && !$job->canRetry($attempt - 1, $error)) {
                 return true;
-            } elseif ($attempt > $this->attempts) {
+            } elseif (!($job instanceof RetryableJobInterface) && $attempt > $this->attempts) {
                 return true;
             }
         }

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -225,6 +225,11 @@ abstract class Queue extends Component
     protected function handleMessage($id, $message, $ttr, $attempt)
     {
         list($job, $error) = $this->unserializeMessage($message);
+
+        if ($attempt > 1 && !($job instanceof RetryableJobInterface)) {
+            return false;
+        }
+
         $event = new ExecEvent([
             'id' => $id,
             'job' => $job,

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -228,7 +228,7 @@ abstract class Queue extends Component
 
         // Handle aborted jobs without thrown error
         if ($attempt > 1) {
-            if ($job instanceof RetryableJobInterface && !$job->canRetry($attempt, $error)) {
+            if ($job instanceof RetryableJobInterface && !$job->canRetry($attempt - 1, $error)) {
                 return true;
             } else {
                 // Non RetryableJobs can have a maximum of one attempt

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -226,8 +226,14 @@ abstract class Queue extends Component
     {
         list($job, $error) = $this->unserializeMessage($message);
 
-        if ($attempt > 1 && !($job instanceof RetryableJobInterface)) {
-            return false;
+        // Handle aborted jobs without thrown error
+        if ($attempt > 1) {
+            if ($job instanceof RetryableJobInterface && !$job->canRetry($attempt, $error)) {
+                return true;
+            } else {
+                // Non RetryableJobs can have a maximum of one attempt
+                return true;
+            }
         }
 
         $event = new ExecEvent([

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -227,12 +227,10 @@ abstract class Queue extends Component
         list($job, $error) = $this->unserializeMessage($message);
 
         // Handle aborted jobs without thrown error
-        if ($attempt > 1) {
-            if ($job instanceof RetryableJobInterface && !$job->canRetry($attempt - 1, $error)) {
-                return true;
-            } elseif (!($job instanceof RetryableJobInterface) && $attempt > $this->attempts) {
-                return true;
-            }
+        if ($attempt > 1 &&
+            (($job instanceof RetryableJobInterface && !$job->canRetry($attempt - 1, $error))
+            || (!($job instanceof RetryableJobInterface) && $attempt > $this->attempts))) {
+            return true;
         }
 
         $event = new ExecEvent([

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -226,7 +226,7 @@ abstract class Queue extends Component
     {
         list($job, $error) = $this->unserializeMessage($message);
 
-        // Handle aborted jobs without thrown error
+        // Handle aborted jobs without throwing an error.
         if ($attempt > 1 &&
             (($job instanceof RetryableJobInterface && !$job->canRetry($attempt - 1, $error))
             || (!($job instanceof RetryableJobInterface) && $attempt > $this->attempts))) {

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -228,7 +228,7 @@ abstract class Queue extends Component
 
         // Handle aborted jobs without thrown error
         if ($attempt > 1) {
-            if ($job instanceof RetryableJobInterface && !$job->canRetry($attempt, $error)) {
+            if ($job instanceof RetryableJobInterface && !$job->canRetry($attempt - 1, $error)) {
                 return true;
             } elseif ($attempt > $this->attempts) {
                 return true;

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -228,10 +228,9 @@ abstract class Queue extends Component
 
         // Handle aborted jobs without thrown error
         if ($attempt > 1) {
-            if ($job instanceof RetryableJobInterface && !$job->canRetry($attempt - 1, $error)) {
+            if ($job instanceof RetryableJobInterface && !$job->canRetry($attempt, $error)) {
                 return true;
-            } else {
-                // Non RetryableJobs can have a maximum of one attempt
+            } elseif ($attempt > $this->attempts) {
                 return true;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  |❌
| Breaks BC?    | ❌
| Fixed issues  | 

We have the situation that apparently in some environments, jobs canceled by `max_execution_time` are not correctly removed from the queue. As a result, they are executed again and again. Even if no `RetryableJobInterface` is implemented or `canRetry()` always returns `false`.

Unfortunately, I can't reproduce it myself, but some users can in connection with CPanel environments. Perhaps the worker is there not running in CLI but in CGI mode.

In our project, we have now successfully solved the problem using the `ExecEvent`. But maybe it makes sense to add this fix (even if I am not completely happy with it) to the upstream queue project. 

Related issue: https://github.com/humhub/calendar/issues/547#
