### PR TITLE
Fix #563: Fix `@property` annotations in `InfoAction` and `Queue` drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii2 Queue Extension Change Log
 - Enh #503: All dependent packages for supported drivers have been updated to the latest versions (@s1lver)
 - Enh #503: The `opis/closure` package did not support PHP 8.1 and was replaced by the `laravel/serializable-closure` package (@s1lver)
 - Enh #544: Applying Yii2 coding standards (@s1lver)
+- Bug #TBD: Fix `@property` annotations in `InfoAction` and `Queue` drivers (mspirkov)
 
 2.3.8 January 08, 2026
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Yii2 Queue Extension Change Log
 
 3.0.0 under development
 ---
+
 - Enh #542: The minimum supported PHP version is 8.3 (@s1lver)
 - Enh #503, #546: Added PHPStan for static code analysis. Error level set to 8 (@s1lver)
 - Enh #503: Added strict typing (@s1lver)
@@ -14,7 +15,7 @@ Yii2 Queue Extension Change Log
 - Enh #503: All dependent packages for supported drivers have been updated to the latest versions (@s1lver)
 - Enh #503: The `opis/closure` package did not support PHP 8.1 and was replaced by the `laravel/serializable-closure` package (@s1lver)
 - Enh #544: Applying Yii2 coding standards (@s1lver)
-- Bug #TBD: Fix `@property` annotations in `InfoAction` and `Queue` drivers (mspirkov)
+- Bug #563: Fix `@property` annotations in `InfoAction` and `Queue` drivers (mspirkov)
 
 2.3.8 January 08, 2026
 ----------------------

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,6 +55,12 @@ parameters:
 			path: src/cli/Command.php
 
 		-
+			message: '#^Call to an undefined method yii\\base\\Controller\:\:stdout\(\)\.$#'
+			identifier: method.notFound
+			count: 9
+			path: src/cli/InfoAction.php
+
+		-
 			message: '#^Cannot call method getComponents\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -1331,9 +1337,3 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/serializers/TestCase.php
-
-		-
-			message: '#^Access to constant ATTR_INIT_COMMAND on an unknown class Pdo\\Mysql\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/app/config/main.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1337,3 +1337,9 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/serializers/TestCase.php
+
+		-
+			message: '#^Access to constant ATTR_INIT_COMMAND on an unknown class Pdo\\Mysql\.$#'
+			identifier: class.notFound
+			count: 1
+			path: tests/app/config/main.php

--- a/src/cli/InfoAction.php
+++ b/src/cli/InfoAction.php
@@ -23,7 +23,6 @@ use yii\queue\interfaces\WaitingCountInterface;
  * Info about queue status.
  *
  * @author Kalmer Kaurson <kalmerkaurson@gmail.com>
- *
  */
 class InfoAction extends Action
 {

--- a/src/cli/InfoAction.php
+++ b/src/cli/InfoAction.php
@@ -24,7 +24,6 @@ use yii\queue\interfaces\WaitingCountInterface;
  *
  * @author Kalmer Kaurson <kalmerkaurson@gmail.com>
  *
- * @property Controller $controller
  */
 class InfoAction extends Action
 {

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -34,7 +34,6 @@ use yii\queue\cli\Queue as CliQueue;
  * Amqp Queue.
  *
  * @property-read AmqpContext $context
- * @property-read AmqpQueue $queue
  *
  * @author Maksym Kotliar <kotlyar.maksim@gmail.com>
  * @since 2.0.2

--- a/src/drivers/beanstalk/Queue.php
+++ b/src/drivers/beanstalk/Queue.php
@@ -24,8 +24,7 @@ use yii\queue\cli\Queue as CliQueue;
 /**
  * Beanstalk Queue.
  *
- * @property-read TubeName $tubeName
- * @property-read object $statsTube Tube statistics.
+ * @property-read TubeStats $statsTube Tube statistics.
  *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
  */

--- a/src/drivers/db/Queue.php
+++ b/src/drivers/db/Queue.php
@@ -23,7 +23,7 @@ use yii\queue\interfaces\StatisticsProviderInterface;
 /**
  * Db Queue.
  *
- * @property-read StatisticsProvider $statisticsProvider
+ * @property-read StatisticsInterface $statisticsProvider
  *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
  */

--- a/src/drivers/file/Queue.php
+++ b/src/drivers/file/Queue.php
@@ -22,7 +22,7 @@ use yii\queue\interfaces\StatisticsProviderInterface;
 /**
  * File Queue.
  *
- * @property-read StatisticsProvider $statisticsProvider
+ * @property-read StatisticsInterface $statisticsProvider
  *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
  */

--- a/src/drivers/redis/Queue.php
+++ b/src/drivers/redis/Queue.php
@@ -21,7 +21,7 @@ use yii\redis\Connection;
 /**
  * Redis Queue.
  *
- * @property-read StatisticsProvider $statisticsProvider
+ * @property-read StatisticsInterface $statisticsProvider
  *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

See: https://github.com/yiisoft/yii2/pull/21042